### PR TITLE
Run tests on Travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,13 @@
 src/tests/test_ffm_als_mcmc
 src/tests/test_ffm_utils
 src/tests/test_ffm_sgd
+src/tests/test_random
+
+# OS X build-generated directories
+src/tests/test_ffm_als_mcmc.dSYM/
+src/tests/test_ffm_utils.dSYM/
+src/tests/test_random.dSYM/
+
 bin/
 demo/data/ranking_predictions
 dense_fm

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,9 @@ before_install:
 
 install:
     - echo $TRAVIS_OS_NAME
-    - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install glib argp-standalone; fi
+    - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install glib gsl argp-standalone; fi
     - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get update -qq; sudo apt-get install -y libglib2.0-dev libatlas-base-dev libgsl0-dev; fi
 
 script:
     - make
+    - cd src/tests/; make all; make check

--- a/src/tests/Makefile
+++ b/src/tests/Makefile
@@ -6,6 +6,10 @@ LDLIBS= `pkg-config --libs gsl glib-2.0` -L../../externals/CXSparse/Lib -lcxspar
 
 CC=gcc
 
+ifeq ($(shell uname -s),Darwin)
+	CFLAGS += -I$(shell find /System/Library/Frameworks/Accelerate.framework -name 'cblas.h' | xargs dirname)
+endif
+
 all: test_ffm_sgd test_ffm_als_mcmc test_ffm_utils test_random
 	( cd ../../externals/CXSparse ; $(MAKE) library )
 


### PR DESCRIPTION
Hello. I have updated `.travis.yml` and some files to run tests on Travis after finishing the build :white_check_mark:

Importantly, without `gsl`, tests will be failed on OS X even though I replaced `pkg-config --cflags gsl glib-2.0` with `pkg-config --cflags glib-2.0`. So, I again insert `gsl` into the `brew` command. Since its dependency is more complicated than we expected, we need to carefully check if the library can be dropped.
