### PR TITLE
Argp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
 
 install:
     - echo $TRAVIS_OS_NAME
-    - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install glib argp-standalone; fi
+    - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install glib; fi
     - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get update -qq; sudo apt-get install -y libglib2.0-dev libatlas-base-dev libgsl0-dev; fi
 
 script:

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,4 +1,4 @@
-OBJECTS= kmath.o ffm_random.o ffm_als_mcmc.o ffm_utils.o ffm_sgd.o ffm.o  cli.o
+OBJECTS= kmath.o ffm_random.o ffm_als_mcmc.o ffm_utils.o ffm_sgd.o ffm.o
 CFLAGS = `pkg-config --cflags glib-2.0` -std=c99 -fPIC -g -Wall -O3 -I/include -I./src -I../externals/CXSparse/Include
 LDLIBS= `pkg-config --libs glib-2.0` -L../externals/CXSparse/Lib -lcxsparse -lcblas -latlas -lm
 CC=gcc
@@ -25,7 +25,7 @@ lib: $(OBJECTS)
 cli: $(OBJECTS)
 	( cd ../externals/CXSparse ; $(MAKE) library )
 	mkdir -p ../bin/
-	$(CC) $(OBJECTS) $(CFLAGS) $(LDLIBS) -o ../bin/fastfm
+	$(CC) $(OBJECTS) cli.o $(CFLAGS) $(LDLIBS) -o ../bin/fastfm
 
 .PHONY : clean
 clean :


### PR DESCRIPTION
`argp` is only used for the command line interface and is not needed to build the library.
