### PR TITLE
replace glib

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,4 @@ script:
       # run lib demo
     - (cd demo/; make; make demo_lib)
       # run cli demo, linking fails on osx
-    - if [ "$TRAVIS_OS_NAME" = "linux" ]; make cli; (cd demo/; make; make demo_cli); fi
+    - if [ "$TRAVIS_OS_NAME" = "linux" ]; then make cli; (cd demo/; make; make demo_cli); fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,5 @@ script:
     - (cd src/tests/; make all; make check)
       # run lib demo
     - (cd demo/; make; make demo_lib)
-    - make cli
-      # run cli demo
-    - (cd demo/; make; make demo_cli)
-
+      # run cli demo, linking fails on osx
+    - if [ "$TRAVIS_OS_NAME" = "linux" ]; make cli; (cd demo/; make; make demo_cli); fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ install:
     - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get install -y libglib2.0-dev libatlas-base-dev libgsl0-dev; fi
 
 script:
-    - make
       # run test suite
     - (cd src/tests/; make all; make check)
       # run cli demo, linking fails on osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ script:
     - (cd src/tests/; make all; make check)
       # run lib demo
     - (cd demo/; make; make demo_lib)
+    - make cli
       # run cli demo
     - (cd demo/; make; make demo_cli)
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,14 +12,17 @@ before_install:
 
 install:
     - echo $TRAVIS_OS_NAME
+    - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get update -qq; sudo apt-get install -y libatlas-base-dev; fi
+      # build and test library
+    - (cd demo/; make; make demo_lib)
+
+      # install dependencies for cli and testsuite
     - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install glib gsl argp-standalone; fi
-    - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get update -qq; sudo apt-get install -y libglib2.0-dev libatlas-base-dev libgsl0-dev; fi
+    - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get install -y libglib2.0-dev libatlas-base-dev libgsl0-dev; fi
 
 script:
     - make
       # run test suite
     - (cd src/tests/; make all; make check)
-      # run lib demo
-    - (cd demo/; make; make demo_lib)
       # run cli demo, linking fails on osx
     - if [ "$TRAVIS_OS_NAME" = "linux" ]; then make cli; (cd demo/; make; make demo_cli); fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ install:
     - echo $TRAVIS_OS_NAME
     - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get update -qq; sudo apt-get install -y libatlas-base-dev; fi
       # build and test library
+    - make lib
     - (cd demo/; make; make demo_lib)
 
       # install dependencies for cli and testsuite

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ script:
     - make
       # run test suite
     - (cd src/tests/; make all; make check)
+      # run lib demo
+    - (cd demo/; make; make demo_lib)
       # run cli demo
-    - (cd demo/; make; make run)
+    - (cd demo/; make; make demo_cli)
 

--- a/README.rst
+++ b/README.rst
@@ -27,6 +27,8 @@ and for the testsuite also ``sudo apt-get install libgsl0-dev``
 
 Install on OSX
 ===============
+Library compiles on OSX, however console interface doesn't.
+
 Recommended way to manage dependencies is `Homebrew package manager
 <https://brew.sh>`_. If you have brew installed, dependencies can be installed by running command ``brew install glib argp-standalone``.
 

--- a/demo/Makefile
+++ b/demo/Makefile
@@ -1,8 +1,8 @@
 P= example_als_mcmc example_sgd example_sgd_bpr
 VPATH = ../
 OBJECTS= example_als_mcmc.o example_sgd example_sgd_bpr
-CFLAGS = `pkg-config --cflags glib-2.0` -std=c99 -g -Wall -O0 -I../include -L../bin -I../externals/CXSparse/Include
-LDLIBS= -lfastfm `pkg-config --libs glib-2.0`  -L../externals/CXSparse/Lib -lcxsparse -lcblas -lm
+CFLAGS = -std=c99 -g -Wall -O0 -I../include -L../bin -I../externals/CXSparse/Include
+LDLIBS= -lfastfm -L../externals/CXSparse/Lib -lcxsparse -lcblas -lm
 CC=gcc
 
 all: $(P)
@@ -10,10 +10,12 @@ all: $(P)
 
 #test_ffm_sgd.o: fast_fm.h
 
-run:
+demo_lib:
 	./example_sgd
 	./example_sgd_bpr
 	./example_als_mcmc
+
+demo_cli: regression classification
 
 regression:
 	./../bin/fastfm data/train_regression data/test_regression \

--- a/demo/Makefile
+++ b/demo/Makefile
@@ -6,9 +6,8 @@ LDLIBS= -lfastfm -L../externals/CXSparse/Lib -lcxsparse -lcblas -lm
 CC=gcc
 
 all: $(P)
-	$(MAKE) -C ../ lib
+	( cd .. ; $(MAKE) lib)
 
-#test_ffm_sgd.o: fast_fm.h
 
 demo_lib:
 	./example_sgd

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,6 +1,6 @@
 OBJECTS= kmath.o ffm_random.o ffm_als_mcmc.o ffm_utils.o ffm_sgd.o ffm.o
-CFLAGS = `pkg-config --cflags glib-2.0` -std=c99 -fPIC -g -Wall -O3 -I/include -I./src -I../externals/CXSparse/Include
-LDLIBS= `pkg-config --libs glib-2.0` -L../externals/CXSparse/Lib -lcxsparse -lcblas -latlas -lm
+CFLAGS = -std=c99 -fPIC -g -Wall -O3 -I/include -I./src -I../externals/CXSparse/Include
+LDLIBS= -L../externals/CXSparse/Lib -lcxsparse -lcblas -lm
 CC=gcc
 
 ifeq ($(shell uname -s),Darwin)

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,6 +1,6 @@
 OBJECTS= kmath.o ffm_random.o ffm_als_mcmc.o ffm_utils.o ffm_sgd.o ffm.o
 CFLAGS = -std=c99 -fPIC -g -Wall -O3 -I/include -I./src -I../externals/CXSparse/Include
-LDLIBS= -L../externals/CXSparse/Lib -lcxsparse -lcblas -lm
+LDLIBS= -L../externals/CXSparse/Lib -L/usr/local/opt/argp-standalone/lib -lcxsparse -lcblas -lm
 CC=gcc
 
 ifeq ($(shell uname -s),Darwin)

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,6 +1,6 @@
 OBJECTS= kmath.o ffm_random.o ffm_als_mcmc.o ffm_utils.o ffm_sgd.o ffm.o
 CFLAGS = -std=c99 -fPIC -g -Wall -O3 -I/include -I./src -I../externals/CXSparse/Include
-LDLIBS= -L../externals/CXSparse/Lib -L/usr/local/opt/argp-standalone/lib -lcxsparse -lcblas -lm
+LDLIBS= -L../externals/CXSparse/Lib -lcxsparse -lcblas -lm
 CC=gcc
 
 ifeq ($(shell uname -s),Darwin)

--- a/src/Makefile
+++ b/src/Makefile
@@ -22,7 +22,7 @@ lib: $(OBJECTS)
 	mkdir -p ../bin/
 	ar rcs ../bin/libfastfm.a $(OBJECTS)
 
-cli: $(OBJECTS)
+cli: $(OBJECTS) cli.o
 	( cd ../externals/CXSparse ; $(MAKE) library )
 	mkdir -p ../bin/
 	$(CC) $(OBJECTS) cli.o $(CFLAGS) $(LDLIBS) -o ../bin/fastfm
@@ -30,5 +30,6 @@ cli: $(OBJECTS)
 .PHONY : clean
 clean :
 	rm -f $(P) $(OBJECTS)
+	rm -f  *.o
 	rm -f ../bin/libfastfm.a
 	rm -f ../bin/fastfm

--- a/src/cli.c
+++ b/src/cli.c
@@ -2,6 +2,7 @@
 // License: BSD 3 clause
 
 #include "fast_fm.h"
+#include <time.h>
 #include <stdlib.h>
 #include <argp.h>
 #include <fenv.h>

--- a/src/ffm_utils.c
+++ b/src/ffm_utils.c
@@ -2,6 +2,7 @@
 // License: BSD 3 clause
 
 #include "fast_fm.h"
+#include <unistd.h>
 
 // ########################### ffm scalar ###################################
 double ffm_sigmoid(double x){
@@ -355,7 +356,7 @@ double ffm_blas_dnrm2(ffm_vector *x){
 
 ffm_matrix * ffm_matrix_from_file(char *path)
 {
-    assert (g_file_test(path, G_FILE_TEST_EXISTS) && "file doesn't exist");
+    assert(access( path, F_OK ) != -1 && "file doesn't exist");
     FILE *fp =  fopen(path, "r");
 
     // get number of rows
@@ -403,7 +404,7 @@ ffm_matrix * ffm_matrix_from_file(char *path)
 fm_data read_svm_light_file( char *path)
 {
 
-    assert (g_file_test(path, G_FILE_TEST_EXISTS) && "file doesn't exist");
+    assert(access( path, F_OK ) != -1 && "file doesn't exist");
     FILE *fp =  fopen(path, "r");
 
     cs *T = cs_spalloc (0, 0, 1, 1, 1) ;  /* allocate result */

--- a/src/ffm_utils.h
+++ b/src/ffm_utils.h
@@ -5,7 +5,6 @@
 #define FFM_UTILS_H
 
 #include "fast_fm.h"
-#include <glib.h>
 
 // ########################### ffm scalar ###################################
 double ffm_sigmoid(double x);

--- a/src/kvec.h
+++ b/src/kvec.h
@@ -1,0 +1,90 @@
+/* The MIT License
+
+   Copyright (c) 2008, by Attractive Chaos <attractor@live.co.uk>
+
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   "Software"), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
+   distribute, sublicense, and/or sell copies of the Software, and to
+   permit persons to whom the Software is furnished to do so, subject to
+   the following conditions:
+
+   The above copyright notice and this permission notice shall be
+   included in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+   NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+   BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+   ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+   CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+   SOFTWARE.
+*/
+
+/*
+  An example:
+
+#include "kvec.h"
+int main() {
+	kvec_t(int) array;
+	kv_init(array);
+	kv_push(int, array, 10); // append
+	kv_a(int, array, 20) = 5; // dynamic
+	kv_A(array, 20) = 4; // static
+	kv_destroy(array);
+	return 0;
+}
+*/
+
+/*
+  2008-09-22 (0.1.0):
+
+	* The initial version.
+
+*/
+
+#ifndef AC_KVEC_H
+#define AC_KVEC_H
+
+#include <stdlib.h>
+
+#define kv_roundup32(x) (--(x), (x)|=(x)>>1, (x)|=(x)>>2, (x)|=(x)>>4, (x)|=(x)>>8, (x)|=(x)>>16, ++(x))
+
+#define kvec_t(type) struct { size_t n, m; type *a; }
+#define kv_init(v) ((v).n = (v).m = 0, (v).a = 0)
+#define kv_destroy(v) free((v).a)
+#define kv_A(v, i) ((v).a[(i)])
+#define kv_pop(v) ((v).a[--(v).n])
+#define kv_size(v) ((v).n)
+#define kv_max(v) ((v).m)
+
+#define kv_resize(type, v, s)  ((v).m = (s), (v).a = (type*)realloc((v).a, sizeof(type) * (v).m))
+
+#define kv_copy(type, v1, v0) do {							\
+		if ((v1).m < (v0).n) kv_resize(type, v1, (v0).n);	\
+		(v1).n = (v0).n;									\
+		memcpy((v1).a, (v0).a, sizeof(type) * (v0).n);		\
+	} while (0)												\
+
+#define kv_push(type, v, x) do {									\
+		if ((v).n == (v).m) {										\
+			(v).m = (v).m? (v).m<<1 : 2;							\
+			(v).a = (type*)realloc((v).a, sizeof(type) * (v).m);	\
+		}															\
+		(v).a[(v).n++] = (x);										\
+	} while (0)
+
+#define kv_pushp(type, v) (((v).n == (v).m)?							\
+						   ((v).m = ((v).m? (v).m<<1 : 2),				\
+							(v).a = (type*)realloc((v).a, sizeof(type) * (v).m), 0)	\
+						   : 0), ((v).a + ((v).n++))
+
+#define kv_a(type, v, i) (((v).m <= (size_t)(i)? \
+						  ((v).m = (v).n = (i) + 1, kv_roundup32((v).m), \
+						   (v).a = (type*)realloc((v).a, sizeof(type) * (v).m), 0) \
+						  : (v).n <= (size_t)(i)? (v).n = (i) + 1 \
+						  : 0), (v).a[(i)])
+
+#endif

--- a/src/tests/TestFixtures.h
+++ b/src/tests/TestFixtures.h
@@ -1,4 +1,5 @@
 #include "fast_fm.h"
+#include <glib.h>
 
 typedef struct TestFixture_T {
     cs *X;

--- a/src/tests/test_ffm_utils.c
+++ b/src/tests/test_ffm_utils.c
@@ -1,4 +1,5 @@
 #include "fast_fm.h"
+#include <glib.h>
 
 
 void test_ffm_vector_mean(void){

--- a/src/tests/test_random.c
+++ b/src/tests/test_random.c
@@ -1,4 +1,5 @@
 #include "fast_fm.h"
+#include <glib.h>
 
 
 void test_rng_seed(void){


### PR DESCRIPTION
`glib` is only used in `fm_utils.c`
replace
- [x]  `g_file`
- [x]  `g_array` with `kvec.h`
- [x] travis, build lib without glib and argp installed
