### PR TITLE
[Issue #85] Adding OpenBLAS as external lib.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,6 @@
 	path = externals/CXSparse
 	url = https://github.com/ibayer/CXSparse.git
 
+[submodule "externals/OpenBLAS"]
+	path = externals/OpenBLAS
+	url = https://github.com/xianyi/OpenBLAS.git

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@ lib: $(OBJECTS)
 	( cd src ; $(MAKE) lib )
 
 cli:
+	( cd externals/CXSparse ; $(MAKE) library )
+	( cd externals/OpenBLAS ; $(MAKE) libs)
 	( cd src ; $(MAKE) cli )
 
 .PHONY : clean

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 
 lib: $(OBJECTS)
 	( cd externals/CXSparse ; $(MAKE) library )
-	( cd externals/OpenBLAS ; $(MAKE) )
+	( cd externals/OpenBLAS ; $(MAKE) libs)
 	( cd src ; $(MAKE) lib )
 
 cli:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 
 lib: $(OBJECTS)
+	( cd externals/CXSparse ; $(MAKE) library )
+	( cd externals/OpenBLAS ; $(MAKE) )
 	( cd src ; $(MAKE) lib )
 
 cli:

--- a/demo/Makefile
+++ b/demo/Makefile
@@ -1,9 +1,8 @@
 P= example_als_mcmc example_sgd example_sgd_bpr
 VPATH = ../
 OBJECTS = example_als_mcmc.o example_sgd example_sgd_bpr
-INCLUDE = -I../include -L../bin -I../externals/CXSparse/Include -I../externals/OpenBLAS
-CFLAGS = -std=c99 -g -Wall -O0 $(INCLUDE)
-LDLIBS = -L../bin -lfastfm -lopenblas -lpthread -lm
+CFLAGS = -std=c99 -g -Wall -O0
+LDLIBS = -L../bin -lfastfm -lpthread -lm
 CC = gcc
 
 all: $(P)

--- a/demo/Makefile
+++ b/demo/Makefile
@@ -3,7 +3,7 @@ VPATH = ../
 OBJECTS = example_als_mcmc.o example_sgd example_sgd_bpr
 INCLUDE = -I../include -L../bin -I../externals/CXSparse/Include -I../externals/OpenBLAS
 CFLAGS = -std=c99 -g -Wall -O0 $(INCLUDE)
-LDLIBS = -L../bin -lfastfm -L../externals/CXSparse/Lib -lcxsparse
+LDLIBS = -L../bin -lfastfm -L../externals/CXSparse/Lib -lcxsparse -lm
 CC = gcc
 
 all: $(P)

--- a/demo/Makefile
+++ b/demo/Makefile
@@ -3,7 +3,7 @@ VPATH = ../
 OBJECTS = example_als_mcmc.o example_sgd example_sgd_bpr
 INCLUDE = -I../include -L../bin -I../externals/CXSparse/Include -I../externals/OpenBLAS
 CFLAGS = -std=c99 -g -Wall -O0 $(INCLUDE)
-LDLIBS = -L../bin -lfastfm -L../externals/CXSparse/Lib -lcxsparse -L../externals/OpenBLAS -lopenblas -lpthread -lm
+LDLIBS = -L../bin -lfastfm -lopenblas -lpthread -lm
 CC = gcc
 
 all: $(P)

--- a/demo/Makefile
+++ b/demo/Makefile
@@ -1,7 +1,8 @@
 P= example_als_mcmc example_sgd example_sgd_bpr
 VPATH = ../
 OBJECTS = example_als_mcmc.o example_sgd example_sgd_bpr
-CFLAGS = -std=c99 -g -Wall -O0 -I../include -L../bin -I../externals/CXSparse/Include
+INCLUDE = -I../include -L../bin -I../externals/CXSparse/Include -I../externals/OpenBLAS
+CFLAGS = -std=c99 -g -Wall -O0 $(INCLUDE)
 LDLIBS = -L../bin -lfastfm -L../externals/CXSparse/Lib -lcxsparse
 CC = gcc
 

--- a/demo/Makefile
+++ b/demo/Makefile
@@ -1,9 +1,9 @@
 P= example_als_mcmc example_sgd example_sgd_bpr
 VPATH = ../
-OBJECTS= example_als_mcmc.o example_sgd example_sgd_bpr
+OBJECTS = example_als_mcmc.o example_sgd example_sgd_bpr
 CFLAGS = -std=c99 -g -Wall -O0 -I../include -L../bin -I../externals/CXSparse/Include
-LDLIBS= -lfastfm -L../externals/CXSparse/Lib -lcxsparse -lblas -lm
-CC=gcc
+LDLIBS = -L../bin -lfastfm -L../externals/CXSparse/Lib -lcxsparse
+CC = gcc
 
 all: $(P)
 	( cd .. ; $(MAKE) lib)

--- a/demo/Makefile
+++ b/demo/Makefile
@@ -3,7 +3,7 @@ VPATH = ../
 OBJECTS = example_als_mcmc.o example_sgd example_sgd_bpr
 INCLUDE = -I../include -L../bin -I../externals/CXSparse/Include -I../externals/OpenBLAS
 CFLAGS = -std=c99 -g -Wall -O0 $(INCLUDE)
-LDLIBS = -L../bin -lfastfm -L../externals/CXSparse/Lib -lcxsparse -L../externals/OpenBLAS -lblas -lm
+LDLIBS = -L../bin -lfastfm -L../externals/CXSparse/Lib -lcxsparse -L../externals/OpenBLAS -lopenblas -lpthread -lm
 CC = gcc
 
 all: $(P)

--- a/demo/Makefile
+++ b/demo/Makefile
@@ -3,7 +3,7 @@ VPATH = ../
 OBJECTS = example_als_mcmc.o example_sgd example_sgd_bpr
 INCLUDE = -I../include -L../bin -I../externals/CXSparse/Include -I../externals/OpenBLAS
 CFLAGS = -std=c99 -g -Wall -O0 $(INCLUDE)
-LDLIBS = -L../bin -lfastfm -L../externals/CXSparse/Lib -lcxsparse -lm
+LDLIBS = -L../bin -lfastfm -L../externals/CXSparse/Lib -lcxsparse -L../externals/OpenBLAS -lblas -lm
 CC = gcc
 
 all: $(P)

--- a/src/Makefile
+++ b/src/Makefile
@@ -16,7 +16,7 @@ cli.o : fast_fm.h
 
 lib: $(OBJECTS)
 	( cd ../externals/CXSparse ; $(MAKE) library )
-	( cd ../externals/OpenBLAS ; $(MAKE) libs )
+	( cd ../externals/OpenBLAS ; $(MAKE) )
 	mkdir -p ../bin/
 	ar -x ../externals/CXSparse/Lib/libcxsparse.a
 	ar -x ../externals/OpenBLAS/libopenblas.a
@@ -24,7 +24,7 @@ lib: $(OBJECTS)
 
 cli: $(OBJECTS) cli.o
 	( cd ../externals/CXSparse ; $(MAKE) library )
-	( cd ../externals/OpenBLAS ; $(MAKE) libs )
+	( cd ../externals/OpenBLAS ; $(MAKE) )
 	mkdir -p ../bin/
 	$(CC) $(OBJECTS) cli.o $(CFLAGS) $(INCLUDES) $(LDLIBS) -o ../bin/fastfm
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -23,7 +23,7 @@ lib: $(OBJECTS)
 	mkdir -p ../bin/
 	ar -x ../externals/CXSparse/Lib/libcxsparse.a
 	ar -x ../externals/OpenBLAS/libopenblas.a
-	ar rcs ../bin/libfastfm.a $(OBJECTS)
+	ar rcs ../bin/libfastfm.a $(OBJECTS) *.o
 
 cli: $(OBJECTS) cli.o
 	( cd ../externals/CXSparse ; $(MAKE) library )

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,6 +1,6 @@
 OBJECTS = kmath.o ffm_random.o ffm_als_mcmc.o ffm_utils.o ffm_sgd.o ffm.o
 INCLUDES = -I/include -I./src -I../externals/CXSparse/Include  -I../externals/OpenBLAS
-LDLIBS = -L../externals/CXSparse/Lib -lcxsparse -L../externals/OpenBLAS -lopenblas
+LDLIBS = -L../externals/CXSparse/Lib -lcxsparse -L../externals/OpenBLAS -lopenblas -lm
 CFLAGS = -std=c99 -fPIC -g -Wall -O3 $(INCLUDES)
 CC=gcc
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,5 +1,5 @@
 OBJECTS = kmath.o ffm_random.o ffm_als_mcmc.o ffm_utils.o ffm_sgd.o ffm.o
-INCLUDES = -I/include -I./src -I../externals/CXSparse/Include  -I../externals/OpenBLAS
+INCLUDES =  -I../externals/OpenBLAS
 LDLIBS = -L../bin -lfastfm -lpthread -lm
 CFLAGS = -std=c99 -fPIC -g -Wall -O3 $(INCLUDES)
 CC=gcc

--- a/src/Makefile
+++ b/src/Makefile
@@ -19,7 +19,10 @@ cli.o : fast_fm.h
 
 lib: $(OBJECTS)
 	( cd ../externals/CXSparse ; $(MAKE) library )
+	( cd ../externals/OpenBLAS ; $(MAKE) libs )
 	mkdir -p ../bin/
+	ar -x ../externals/CXSparse/Lib/libcxsparse.a
+	ar -x ../externals/OpenBLAS/libopenblas.a
 	ar rcs ../bin/libfastfm.a $(OBJECTS)
 
 cli: $(OBJECTS) cli.o

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,6 +1,6 @@
 OBJECTS = kmath.o ffm_random.o ffm_als_mcmc.o ffm_utils.o ffm_sgd.o ffm.o
 INCLUDES = -I/include -I./src -I../externals/CXSparse/Include  -I../externals/OpenBLAS
-LDLIBS = -L../externals/CXSparse/Lib -lcxsparse -L../externals/OpenBLAS -lblas
+LDLIBS = -L../externals/CXSparse/Lib -lcxsparse -L../externals/OpenBLAS -lopenblas
 CFLAGS = -std=c99 -fPIC -g -Wall -O3 $(INCLUDES)
 CC=gcc
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,6 +1,5 @@
 OBJECTS = kmath.o ffm_random.o ffm_als_mcmc.o ffm_utils.o ffm_sgd.o ffm.o
 INCLUDES =  -I../externals/OpenBLAS
-LDLIBS = -L../bin -lfastfm -lpthread -lm
 CFLAGS = -std=c99 -fPIC -g -Wall -O3 $(INCLUDES)
 CC=gcc
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,6 +1,6 @@
 OBJECTS = kmath.o ffm_random.o ffm_als_mcmc.o ffm_utils.o ffm_sgd.o ffm.o
 INCLUDES =  -I../externals/OpenBLAS
-LDLIBS = -L../bin -lfastfm -lpthread -lm
+LDLIBS = -L../externals/CXSparse/Lib -lcxsparse  -L../externals/OpenBLAS -lopenblas -lpthread -lm
 CFLAGS = -std=c99 -fPIC -g -Wall -O3 $(INCLUDES)
 CC=gcc
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -15,16 +15,12 @@ cli.o : fast_fm.h
 
 
 lib: $(OBJECTS)
-	( cd ../externals/CXSparse ; $(MAKE) library )
-	( cd ../externals/OpenBLAS ; $(MAKE) )
 	mkdir -p ../bin/
 	ar -x ../externals/CXSparse/Lib/libcxsparse.a
 	ar -x ../externals/OpenBLAS/libopenblas.a
 	ar rcs ../bin/libfastfm.a $(OBJECTS) *.o
 
 cli: $(OBJECTS) cli.o
-	( cd ../externals/CXSparse ; $(MAKE) library )
-	( cd ../externals/OpenBLAS ; $(MAKE) )
 	mkdir -p ../bin/
 	$(CC) $(OBJECTS) cli.o $(CFLAGS) $(INCLUDES) $(LDLIBS) -o ../bin/fastfm
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,6 +1,6 @@
 OBJECTS = kmath.o ffm_random.o ffm_als_mcmc.o ffm_utils.o ffm_sgd.o ffm.o
 INCLUDES = -I/include -I./src -I../externals/CXSparse/Include  -I../externals/OpenBLAS
-LDLIBS = -L../externals/CXSparse/Lib -lcxsparse -L../externals/OpenBLAS -lopenblas -lm
+LDLIBS = -L../externals/CXSparse/Lib -lcxsparse -L../externals/OpenBLAS -lopenblas -lpthread -lm
 CFLAGS = -std=c99 -fPIC -g -Wall -O3 $(INCLUDES)
 CC=gcc
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,6 +1,6 @@
 OBJECTS = kmath.o ffm_random.o ffm_als_mcmc.o ffm_utils.o ffm_sgd.o ffm.o
 INCLUDES = -I/include -I./src -I../externals/CXSparse/Include  -I../externals/OpenBLAS
-LDLIBS = -L../externals/CXSparse/Lib -lcxsparse -L../externals/OpenBLAS -lopenblas -lpthread -lm
+LDLIBS = -L../bin -lfastfm -lpthread -lm
 CFLAGS = -std=c99 -fPIC -g -Wall -O3 $(INCLUDES)
 CC=gcc
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,5 +1,6 @@
 OBJECTS = kmath.o ffm_random.o ffm_als_mcmc.o ffm_utils.o ffm_sgd.o ffm.o
 INCLUDES =  -I../externals/OpenBLAS
+LDLIBS = -L../bin -lfastfm -lpthread -lm
 CFLAGS = -std=c99 -fPIC -g -Wall -O3 $(INCLUDES)
 CC=gcc
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,11 +1,8 @@
-OBJECTS= kmath.o ffm_random.o ffm_als_mcmc.o ffm_utils.o ffm_sgd.o ffm.o
-CFLAGS = -std=c99 -fPIC -g -Wall -O3 -I/include -I./src -I../externals/CXSparse/Include
-LDLIBS= -L../externals/CXSparse/Lib -lcxsparse -lblas -lm
+OBJECTS = kmath.o ffm_random.o ffm_als_mcmc.o ffm_utils.o ffm_sgd.o ffm.o
+INCLUDES = -I/include -I./src -I../externals/CXSparse/Include  -I../externals/OpenBLAS
+LDLIBS = -L../externals/CXSparse/Lib -lcxsparse -L../externals/OpenBLAS -lblas
+CFLAGS = -std=c99 -fPIC -g -Wall -O3 $(INCLUDES)
 CC=gcc
-
-ifeq ($(shell uname -s),Darwin)
-	CFLAGS += -I$(shell find /System/Library/Frameworks/Accelerate.framework -name 'cblas.h' | xargs dirname)
-endif
 
 $(P): CFLAGS += -DTest_operations 
 $(P): $(OBJECTS)
@@ -27,8 +24,9 @@ lib: $(OBJECTS)
 
 cli: $(OBJECTS) cli.o
 	( cd ../externals/CXSparse ; $(MAKE) library )
+	( cd ../externals/OpenBLAS ; $(MAKE) libs )
 	mkdir -p ../bin/
-	$(CC) $(OBJECTS) cli.o $(CFLAGS) $(LDLIBS) -o ../bin/fastfm
+	$(CC) $(OBJECTS) cli.o $(CFLAGS) $(INCLUDES) $(LDLIBS) -o ../bin/fastfm
 
 .PHONY : clean
 clean :

--- a/src/tests/Makefile
+++ b/src/tests/Makefile
@@ -1,7 +1,7 @@
 P= test_ffm_als_mcmc test_ffm_utils test_ffm_sgd test_random
 VPATH = ../
 OBJECTS= ffm_als_mcmc.o ffm_sgd.o
-INCLUDE = -I.. -I../../externals/CXSparse/Include -I../../externals/OpenBLAS
+INCLUDE = -I.. -I../../externals/OpenBLAS
 CFLAGS = `pkg-config --cflags gsl glib-2.0` -std=c99 -g -Wall -O0 $(INCLUDE)
 LDLIBS= `pkg-config --libs gsl glib-2.0` -L../../bin -lfastfm
 

--- a/src/tests/Makefile
+++ b/src/tests/Makefile
@@ -1,14 +1,11 @@
 P= test_ffm_als_mcmc test_ffm_utils test_ffm_sgd test_random
 VPATH = ../
 OBJECTS= ffm_als_mcmc.o ffm_sgd.o
-CFLAGS = `pkg-config --cflags gsl glib-2.0` -std=c99 -g -Wall -O0 -I.. -I../../externals/CXSparse/Include
+INCLUDE = -I.. -I../../externals/CXSparse/Include -I../../externals/OpenBLAS
+CFLAGS = `pkg-config --cflags gsl glib-2.0` -std=c99 -g -Wall -O0 $(INCLUDE)
 LDLIBS= `pkg-config --libs gsl glib-2.0` -L../../externals/CXSparse/Lib -lcxsparse
 
 CC=gcc
-
-ifeq ($(shell uname -s),Darwin)
-	CFLAGS += -I$(shell find /System/Library/Frameworks/Accelerate.framework -name 'cblas.h' | xargs dirname)
-endif
 
 all: test_ffm_sgd test_ffm_als_mcmc test_ffm_utils test_random
 	( cd ../../externals/CXSparse ; $(MAKE) library )

--- a/src/tests/Makefile
+++ b/src/tests/Makefile
@@ -3,7 +3,7 @@ VPATH = ../
 OBJECTS= ffm_als_mcmc.o ffm_sgd.o
 INCLUDE = -I.. -I../../externals/CXSparse/Include -I../../externals/OpenBLAS
 CFLAGS = `pkg-config --cflags gsl glib-2.0` -std=c99 -g -Wall -O0 $(INCLUDE)
-LDLIBS= `pkg-config --libs gsl glib-2.0` -L../../externals/CXSparse/Lib -lcxsparse
+LDLIBS= `pkg-config --libs gsl glib-2.0` -L../../bin -lfastfm
 
 CC=gcc
 

--- a/src/tests/Makefile
+++ b/src/tests/Makefile
@@ -3,7 +3,7 @@ VPATH = ../
 OBJECTS= ffm_als_mcmc.o ffm_sgd.o
 INCLUDE = -I.. -I../../externals/OpenBLAS
 CFLAGS = `pkg-config --cflags gsl glib-2.0` -std=c99 -g -Wall -O0 $(INCLUDE)
-LDLIBS= `pkg-config --libs gsl glib-2.0` -L../../bin -lfastfm
+LDLIBS= `pkg-config --libs gsl glib-2.0` -L../../externals/CXSparse/Lib -lcxsparse
 
 CC=gcc
 


### PR DESCRIPTION
Look at https://github.com/ibayer/fastFM/issues/85. OpenBLAS is needed for linking with fastfm.a.